### PR TITLE
improve codebase and performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,6 @@ on:
 jobs:
   test:
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
+    with:
+      lint: true
   

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/benchmark/combined.js
+++ b/benchmark/combined.js
@@ -1,5 +1,4 @@
 'use strict'
-
 const benchmark = require('benchmark')
 
 const forwarded = require('..')
@@ -9,10 +8,15 @@ const req2 = fakerequest({ 'x-forwarded-for': '192.168.0.10, 192.168.1.20' })
 const req5 = fakerequest({ 'x-forwarded-for': '192.168.0.10, 192.168.1.20, 192.168.1.21, 192.168.1.22, 192.168.1.23' })
 
 new benchmark.Suite()
-  .add('no header', function () { forwarded(req0) }, { minSamples: 100 })
-  .add('1 address', function () { forwarded(req1) }, { minSamples: 100 })
-  .add('2 addresses', function () { forwarded(req2) }, { minSamples: 100 })
-  .add('5 addresses', function () { forwarded(req5) }, { minSamples: 100 })
+  .add('combined',
+    function combined () {
+      forwarded(req0)
+      forwarded(req1)
+      forwarded(req2)
+      forwarded(req5)
+    },
+    { minSamples: 100 }
+  )
   .on('cycle', function onCycle (event) { console.log(String(event.target)) })
   .run({ async: false })
 

--- a/index.js
+++ b/index.js
@@ -41,14 +41,12 @@ function parse (header, socketAddr) {
     char = header[i]
     if (char === ' ') {
       (start === end) && (start = end = i)
-      continue
-    }
-    if (char === ',') {
+    } else if (char === ',') {
       (start !== end) && result.push(header.slice(start, end))
       start = end = i
-      continue
+    } else {
+      start = i
     }
-    start = i
   }
 
   (start !== end) && result.push(header.substring(start, end))

--- a/index.js
+++ b/index.js
@@ -7,13 +7,8 @@
 'use strict'
 
 /**
- * Get all addresses in the request, using the `X-Forwarded-For` header.
- *
- * @param {object} req
- * @return {array}
- * @public
+ * Get all addresses in the request used in the `X-Forwarded-For` header.
  */
-
 function forwarded (req) {
   if (!req) {
     throw new TypeError('argument req is required')

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "scripts": {
     "bench": "node benchmark/index.js",
-    "bench:combined": "node benchmark/index.js",
+    "bench:combined": "node benchmark/combined.js",
     "lint": "standard",
     "lint:fix": "standard --fix",
     "test": "npm run test:unit && npm run test:typescript",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "2.0.0",
   "contributors": [
     "Matteo Collina <hello@matteocollina.com>",
-    "Douglas Christopher Wilson <doug@somethingdoug.com>"
+    "Douglas Christopher Wilson <doug@somethingdoug.com>",
+    "Aras Abbasi <aras.abbasi@gmail.com"
   ],
   "license": "MIT",
   "keywords": [
@@ -21,19 +22,29 @@
   },
   "homepage": "https://github.com/fastify/forwarded#readme",
   "devDependencies": {
-    "beautify-benchmark": "0.2.4",
+    "@types/node": "^18.0.3",
     "benchmark": "2.1.4",
     "standard": "^17.0.0",
-    "tap": "^16.0.0"
+    "tap": "^16.0.0",
+    "tsd": "^0.22.0"
   },
+  "engines": {
+    "node": ">=14"
+  },
+  "types": "types/index.d.ts",
   "files": [
     "LICENSE",
-    "HISTORY.md",
     "README.md",
-    "index.js"
+    "index.js",
+    "types/index.d.ts"
   ],
   "scripts": {
     "bench": "node benchmark/index.js",
-    "test": "standard && tap"
+    "bench:combined": "node benchmark/index.js",
+    "lint": "standard",
+    "lint:fix": "standard --fix",
+    "test": "npm run test:unit && npm run test:typescript",
+    "test:unit": "tap",
+    "test:typescript": "tsd"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -54,6 +54,38 @@ test('should trim leading OWS', function (t) {
   t.same(forwarded(req), ['127.0.0.1', '10.0.0.1', '10.0.0.2'])
 })
 
+test('should handle correctly when beginning with a comma', function (t) {
+  t.plan(1)
+  const req = createReq('127.0.0.1', {
+    'x-forwarded-for': ', 10.0.0.2 ,  , 10.0.0.1'
+  })
+  t.same(forwarded(req), ['127.0.0.1', '10.0.0.1', '10.0.0.2'])
+})
+
+test('should handle correctly when ending with a comma', function (t) {
+  t.plan(1)
+  const req = createReq('127.0.0.1', {
+    'x-forwarded-for': '10.0.0.2 ,  , 10.0.0.1,'
+  })
+  t.same(forwarded(req), ['127.0.0.1', '10.0.0.1', '10.0.0.2'])
+})
+
+test('should trim trailing OWS before a comma', function (t) {
+  t.plan(1)
+  const req = createReq('127.0.0.1', {
+    'x-forwarded-for': ' , 10.0.0.2 ,  , 10.0.0.1'
+  })
+  t.same(forwarded(req), ['127.0.0.1', '10.0.0.1', '10.0.0.2'])
+})
+
+test('should trim trailing OWS after a comma', function (t) {
+  t.plan(1)
+  const req = createReq('127.0.0.1', {
+    'x-forwarded-for': ' 10.0.0.2 ,  , 10.0.0.1 , '
+  })
+  t.same(forwarded(req), ['127.0.0.1', '10.0.0.1', '10.0.0.2'])
+})
+
 function createReq (socketAddr, headers) {
   return {
     socket: {

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,14 @@ test('should include entries from X-Forwarded-For', function (t) {
   t.same(forwarded(req), ['127.0.0.1', '10.0.0.1', '10.0.0.2'])
 })
 
+test('should include entries from X-Forwarded-For', function (t) {
+  t.plan(1)
+  const req = createReq('127.0.0.1', {
+    'x-forwarded-for': '10.0.0.1'
+  })
+  t.same(forwarded(req), ['127.0.0.1', '10.0.0.1'])
+})
+
 test('should skip blank entries', function (t) {
   t.plan(1)
   const req = createReq('127.0.0.1', {

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,14 @@ test('should include entries from X-Forwarded-For', function (t) {
 test('should include entries from X-Forwarded-For', function (t) {
   t.plan(1)
   const req = createReq('127.0.0.1', {
+    'x-forwarded-for': '   '
+  })
+  t.same(forwarded(req), ['127.0.0.1'])
+})
+
+test('should include entries from X-Forwarded-For', function (t) {
+  t.plan(1)
+  const req = createReq('127.0.0.1', {
     'x-forwarded-for': '10.0.0.1'
   })
   t.same(forwarded(req), ['127.0.0.1', '10.0.0.1'])

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage } from 'node:http';
 
 /**
- * Get all addresses in the request, using the `X-Forwarded-For` header.
+ * Get all addresses in the request used in the `X-Forwarded-For` header.
  */
 declare function forwarded(req: IncomingMessage): string[];
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage } from 'node:http';
+import { IncomingMessage } from 'http';
 
 /**
  * Get all addresses in the request used in the `X-Forwarded-For` header.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,11 @@
+import { IncomingMessage } from 'node:http';
+
+/**
+ * Get all addresses in the request, using the `X-Forwarded-For` header.
+ */
+declare function forwarded(req: IncomingMessage): string[];
+
+export default forwarded
+export {
+  forwarded
+}

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,0 +1,12 @@
+import { IncomingMessage } from "http";
+import { expectError, expectType } from "tsd";
+import { forwarded } from "..";
+import forwardedESM from "..";
+import * as forwardedVarImport from "..";
+
+expectType<string[]>(forwardedESM({} as IncomingMessage))
+expectType<string[]>(forwarded({} as IncomingMessage))
+expectType<string[]>(forwardedVarImport.default({} as IncomingMessage))
+expectType<string[]>(forwardedVarImport.forwarded({} as IncomingMessage))
+expectError(forwarded())
+expectError(forwarded('10.0.0.1'))


### PR DESCRIPTION
before:

```
  no header   x 9,918,143 ops/sec ±0.41% (193 runs sampled)
  1 address   x 6,509,341 ops/sec ±0.59% (190 runs sampled)
  2 addresses x 3,776,782 ops/sec ±1.24% (188 runs sampled)
  5 addresses x 2,228,356 ops/sec ±0.28% (181 runs sampled)
```

after:
```
no header   x 1,246,115,625 ops/sec ±0.24% (196 runs sampled)
  1 address   x    66,139,899 ops/sec ±0.91% (193 runs sampled)
  2 addresses x    10,107,089 ops/sec ±0.34% (195 runs sampled)
  5 addresses x     4,374,716 ops/sec ±0.48% (194 runs sampled)
```