### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage } from 'http'
+import { IncomingMessage } from 'node:http'
 
 type Forwarded = (req: IncomingMessage) => string[]
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage } from 'http'
+import { IncomingMessage } from 'node:http'
 import { expectError, expectType } from 'tsd'
 import { forwarded } from '..'
 import forwardedESM from '..'


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.